### PR TITLE
Update DrawIO Installation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM public.ecr.aws/docker/library/python:3.13-bullseye
 
 RUN apt-get update \
     && apt-get install -y apt-transport-https ca-certificates wget curl \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: 3.x
       - name: Install Drawio
         run: |
-          sudo apt-get install -y graphviz wget curl libgbm-dev libasound2 xvfb
+          sudo apt-get install -y graphviz wget curl libgbm-dev libasound2-dev xvfb
           curl -s https://api.github.com/repos/jgraph/drawio-desktop/releases/latest | grep browser_download_url | grep '\.deb' | cut -d '"' -f 4 | wget -i -
           sudo apt -f install -y ./drawio-amd64-*.deb
       - name: Install dependencies

--- a/docs/application-pipeline/ri-cdk-pipeline.md
+++ b/docs/application-pipeline/ri-cdk-pipeline.md
@@ -39,7 +39,7 @@ Developers need fast-feedback for potential issues with their code. Automation s
     The application source code is stored in [AWS CodeCommit](https://aws.amazon.com/codecommit/) repository that is created and initialized from the CDK application in the `CodeCommitSource` construct:
 
     <!--codeinclude-->
-    [](../../examples/cdk-application-pipeline/infrastructure/src/codecommit-source/index.ts) inside_block:constructor
+    [](../../examples/cdk-application-pipeline/infrastructure/src/setup.ts) inside_block:constructor
     <!--/codeinclude-->
 
 ???+ required "Test Source Code"


### PR DESCRIPTION
DrawIO has an dependency on `libasound2` which has been updated to `libasound2-dev`.  

Additionally, there was a small bug in the recent update the CDK Application where a broken reference was made to the old CodeCommit Source code. This has also been updated.